### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-clik.ninja


### PR DESCRIPTION
The domain name clik.ninja is unused and the file makes  http://njb-said.github.io/clik.ninja redirect to it which means the game is inaccessible without downloading it.